### PR TITLE
Move remark-emoji in transformer-remark plugins

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,7 +33,6 @@ module.exports = {
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     `gatsby-plugin-sass`,
-    `gatsby-remark-emoji`, // Emoji list: https://emojipedia.org/joypixels/
     {
       resolve: `gatsby-transformer-remark`,
       options: {
@@ -76,6 +75,7 @@ module.exports = {
               ignoreFileExtensions: [`png`, `jpg`, `jpeg`, `bmp`, `tiff`],
             },
           },
+          `gatsby-remark-emoji`, // Emoji list: https://emojipedia.org/joypixels/
         ],
       },
     },


### PR DESCRIPTION
`gatsby-remark-emoji` plugin does not correctly work unless it's added inside the `gatsby-transformer-remark` plugins.